### PR TITLE
bloom effect on WebGPU based on blur example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@triadica/lagopus",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
-  "main": "./lib/index.mjs",
+  "module": "./lib/index.mjs",
   "scripts": {
     "compile": "rm -rfv lib/* && tsc -d --project tsconfig.json --outDir lib/",
     "prepare": "yarn compile"
@@ -16,8 +16,6 @@
   },
   "dependencies": {
     "@triadica/touch-control": "^0.0.2",
-    "@types/ua-parser-js": "^0.7.36",
-    "ismobilejs": "^1.1.1",
-    "ua-parser-js": "^1.0.35"
+    "ismobilejs": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triadica/lagopus",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "module": "./lib/index.mjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triadica/lagopus",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "main": "./lib/index.mjs",
   "scripts": {
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@triadica/touch-control": "^0.0.2",
-    "ismobilejs": "^1.1.1"
+    "@types/ua-parser-js": "^0.7.36",
+    "ismobilejs": "^1.1.1",
+    "ua-parser-js": "^1.0.35"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triadica/lagopus",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "module": "./lib/index.mjs",
   "scripts": {

--- a/shaders/blur.wgsl
+++ b/shaders/blur.wgsl
@@ -1,0 +1,85 @@
+//! based on
+//! https://github.com/webgpu/webgpu-samples/blob/main/src/sample/imageBlur/blur.wgsl
+
+struct Params {
+  filterDim : i32,
+  blockDim : u32,
+}
+
+@group(0) @binding(0) var samp: sampler;
+@group(0) @binding(1) var<uniform> params: Params;
+@group(1) @binding(1) var inputTex: texture_2d<f32>;
+@group(1) @binding(2) var outputTex: texture_storage_2d<rgba8unorm, write>;
+
+struct Flip {
+  value : u32,
+}
+@group(1) @binding(3) var<uniform> flip : Flip;
+
+// This shader blurs the input texture in one direction, depending on whether
+// |flip.value| is 0 or 1.
+// It does so by running (128 / 4) threads per workgroup to load 128
+// texels into 4 rows of shared memory. Each thread loads a
+// 4 x 4 block of texels to take advantage of the texture sampling
+// hardware.
+// Then, each thread computes the blur result by averaging the adjacent texel values
+// in shared memory.
+// Because we're operating on a subset of the texture, we cannot compute all of the
+// results since not all of the neighbors are available in shared memory.
+// Specifically, with 128 x 128 tiles, we can only compute and write out
+// square blocks of size 128 - (filterSize - 1). We compute the number of blocks
+// needed in Javascript and dispatch that amount.
+
+var<workgroup> tile : array<array<vec3<f32>, 128>, 4>;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(
+  @builtin(workgroup_id) WorkGroupID : vec3<u32>,
+  @builtin(local_invocation_id) LocalInvocationID : vec3<u32>
+) {
+  let filterOffset = (params.filterDim - 1) / 2;
+  let dims = vec2<i32>(textureDimensions(inputTex, 0));
+  let baseIndex = vec2<i32>(WorkGroupID.xy * vec2(params.blockDim, 4) +
+                            LocalInvocationID.xy * vec2(4, 1))
+                  - vec2(filterOffset, 0);
+
+  for (var r = 0; r < 4; r++) {
+    for (var c = 0; c < 4; c++) {
+      var loadIndex = baseIndex + vec2(c, r);
+      if (flip.value != 0u) {
+        loadIndex = loadIndex.yx;
+      }
+
+      tile[r][4 * LocalInvocationID.x + u32(c)] = textureSampleLevel(
+        inputTex,
+        samp,
+        (vec2<f32>(loadIndex) + vec2<f32>(0.25, 0.25)) / vec2<f32>(dims),
+        0.0
+      ).rgb;
+    }
+  }
+
+  workgroupBarrier();
+
+  for (var r = 0; r < 4; r++) {
+    for (var c = 0; c < 4; c++) {
+      var writeIndex = baseIndex + vec2(c, r);
+      if (flip.value != 0) {
+        writeIndex = writeIndex.yx;
+      }
+
+      let center = i32(4 * LocalInvocationID.x) + c;
+      if (center >= filterOffset &&
+          center < 128 - filterOffset &&
+          all(writeIndex < dims)) {
+        var acc = vec3(0.0, 0.0, 0.0);
+        for (var f = 0; f < params.filterDim; f++) {
+          var i = center + f - filterOffset;
+          acc = acc + (1.0 / f32(params.filterDim)) * tile[r][i];
+        }
+        textureStore(outputTex, writeIndex, vec4(acc, 1.0));
+        // textureStore(outputTex, writeIndex, vec4(0.5, 0.5, 1, 1.0));
+      }
+    }
+  }
+}

--- a/shaders/fullscreen.wgsl
+++ b/shaders/fullscreen.wgsl
@@ -1,0 +1,41 @@
+//! a shader from WGSL samples to render to canvas
+//! https://github.com/webgpu/webgpu-samples/blob/main/src/shaders/fullscreenTexturedQuad.wgsl
+
+@group(0) @binding(0) var mySampler : sampler;
+@group(0) @binding(1) var myTexture : texture_2d<f32>;
+
+struct VertexOutput {
+  @builtin(position) Position : vec4<f32>,
+  @location(0) fragUV : vec2<f32>,
+}
+
+@vertex
+fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
+  const pos = array(
+    vec2( 1.0,  1.0),
+    vec2( 1.0, -1.0),
+    vec2(-1.0, -1.0),
+    vec2( 1.0,  1.0),
+    vec2(-1.0, -1.0),
+    vec2(-1.0,  1.0),
+  );
+
+  const uv = array(
+    vec2(1.0, 0.0),
+    vec2(1.0, 1.0),
+    vec2(0.0, 1.0),
+    vec2(1.0, 0.0),
+    vec2(0.0, 1.0),
+    vec2(0.0, 0.0),
+  );
+
+  var output : VertexOutput;
+  output.Position = vec4(pos[VertexIndex], 0.0, 1.0);
+  output.fragUV = uv[VertexIndex];
+  return output;
+}
+
+@fragment
+fn frag_main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
+  return textureSample(myTexture, mySampler, fragUV);
+}

--- a/shaders/fullscreen.wgsl
+++ b/shaders/fullscreen.wgsl
@@ -3,6 +3,7 @@
 
 @group(0) @binding(0) var mySampler : sampler;
 @group(0) @binding(1) var myTexture : texture_2d<f32>;
+@group(0) @binding(2) var originalTexure : texture_2d<f32>;
 
 struct VertexOutput {
   @builtin(position) Position : vec4<f32>,
@@ -37,5 +38,5 @@ fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 
 @fragment
 fn frag_main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
-  return textureSample(myTexture, mySampler, fragUV);
+  return textureSample(myTexture, mySampler, fragUV) * 1 + textureSample(originalTexure, mySampler, fragUV) * 0;
 }

--- a/shaders/screen-filter.wgsl
+++ b/shaders/screen-filter.wgsl
@@ -38,7 +38,7 @@ fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 @fragment
 fn frag_main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
   let a = textureSample(myTexture, mySampler, fragUV);
-  if (color_strength(a) > 0.5) {
+  if (color_strength(a) > 0.7) {
     return a;
   } else {
     // return vec4(0.6, 0.6, 1.0, 1.0);

--- a/shaders/screen-filter.wgsl
+++ b/shaders/screen-filter.wgsl
@@ -3,7 +3,6 @@
 
 @group(0) @binding(0) var mySampler : sampler;
 @group(0) @binding(1) var myTexture : texture_2d<f32>;
-@group(0) @binding(2) var originalTexure : texture_2d<f32>;
 
 struct VertexOutput {
   @builtin(position) Position : vec4<f32>,
@@ -38,5 +37,15 @@ fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 
 @fragment
 fn frag_main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
-  return textureSample(myTexture, mySampler, fragUV) * 0.5 + textureSample(originalTexure, mySampler, fragUV) * 1;
+  let a = textureSample(myTexture, mySampler, fragUV);
+  if (color_strength(a) > 0.5) {
+    return a;
+  } else {
+    // return vec4(0.6, 0.6, 1.0, 1.0);
+    return vec4(0, 0, 0.0, 1.0);
+  }
+}
+
+fn color_strength(color: vec4<f32>) -> f32 {
+  return dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
 }

--- a/shaders/screen-filter.wgsl
+++ b/shaders/screen-filter.wgsl
@@ -38,8 +38,9 @@ fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 @fragment
 fn frag_main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
   let a = textureSample(myTexture, mySampler, fragUV);
-  if (color_strength(a) > 0.7) {
-    return a;
+  let s = color_strength(a);
+  if (s > 0.6) {
+    return a * s * (s - 0.6) * 4;
   } else {
     // return vec4(0.6, 0.6, 1.0, 1.0);
     return vec4(0, 0, 0.0, 1.0);

--- a/src/config.mts
+++ b/src/config.mts
@@ -1,5 +1,11 @@
 import isMobilejs from "ismobilejs";
+import uaParse from "ua-parser-js";
 
 export let coneBackScale = 0.5;
 
 export let isMobile = isMobilejs(window.navigator).any; // TODO test
+
+export let ua = (() => {
+  let ua = uaParse(window.navigator.userAgent);
+  return ua;
+})();

--- a/src/config.mts
+++ b/src/config.mts
@@ -1,11 +1,5 @@
 import isMobilejs from "ismobilejs";
-import uaParse from "ua-parser-js";
 
 export let coneBackScale = 0.5;
 
 export let isMobile = isMobilejs(window.navigator).any; // TODO test
-
-export let ua = (() => {
-  let ua = uaParse(window.navigator.userAgent);
-  return ua;
-})();

--- a/src/global.mts
+++ b/src/global.mts
@@ -41,3 +41,6 @@ export function wLog<T extends any>(message: string, a: T): T {
   console.warn(message, a);
   return a;
 }
+
+/** to enabled */
+export let atomBloomEnabled = new Atom(false);

--- a/src/global.mts
+++ b/src/global.mts
@@ -10,8 +10,8 @@ export var atomDepthTexture: Atom<GPUTexture> = new Atom(null);
 export let atomCanvasTexture = new Atom(undefined as GPUTexture);
 
 /** ping/pong buffer for bloom effect */
-export let pingBuffer = new Atom(undefined as GPUBuffer);
-export let pongBuffer = new Atom(undefined as GPUBuffer);
+export let atomPingBuffer = new Atom(undefined as GPUBuffer);
+export let atomPongBuffer = new Atom(undefined as GPUBuffer);
 
 export var atomBufferNeedClear: Atom<boolean> = new Atom(true);
 

--- a/src/global.mts
+++ b/src/global.mts
@@ -15,6 +15,9 @@ export let atomPingBuffer = new Atom(undefined as GPUBuffer);
 export let atomPongBuffer = new Atom(undefined as GPUBuffer);
 export let atomScreenFilterBuffer = new Atom(undefined as GPUBuffer);
 
+export let atomPingTexture = new Atom(undefined as GPUTexture);
+export let atomPongTexture = new Atom(undefined as GPUTexture);
+
 export var atomBufferNeedClear: Atom<boolean> = new Atom(true);
 
 export var atomClearColor: Atom<{ r: number; g: number; b: number; a: number }> = new Atom(undefined);

--- a/src/global.mts
+++ b/src/global.mts
@@ -8,10 +8,12 @@ export var atomContext: Atom<GPUCanvasContext> = new Atom(null);
 export var atomDepthTexture: Atom<GPUTexture> = new Atom(null);
 /** as the fake canvas */
 export let atomCanvasTexture = new Atom(undefined as GPUTexture);
+export let atomFilterTexture = new Atom(undefined as GPUTexture);
 
 /** ping/pong buffer for bloom effect */
 export let atomPingBuffer = new Atom(undefined as GPUBuffer);
 export let atomPongBuffer = new Atom(undefined as GPUBuffer);
+export let atomScreenFilterBuffer = new Atom(undefined as GPUBuffer);
 
 export var atomBufferNeedClear: Atom<boolean> = new Atom(true);
 

--- a/src/global.mts
+++ b/src/global.mts
@@ -3,8 +3,15 @@ import { Atom } from "./atom.mjs";
 
 export var atomDevice: Atom<GPUDevice> = new Atom(null);
 export var atomContext: Atom<GPUCanvasContext> = new Atom(null);
+
 /** TODO depth texture is shared by now, not sure which is better */
 export var atomDepthTexture: Atom<GPUTexture> = new Atom(null);
+/** as the fake canvas */
+export let atomCanvasTexture = new Atom(undefined as GPUTexture);
+
+/** ping/pong buffer for bloom effect */
+export let pingBuffer = new Atom(undefined as GPUBuffer);
+export let pongBuffer = new Atom(undefined as GPUBuffer);
 
 export var atomBufferNeedClear: Atom<boolean> = new Atom(true);
 
@@ -22,6 +29,8 @@ export var atomMouseHoldingPaths = new Atom<number[][]>([]);
 export let atomObjectsTree = new Atom<LagopusElement>(null);
 
 export let atomObjectsBuffer = new Atom<LagopusObjectBuffer[]>([]);
+
+export let atomCommandEncoder = new Atom<GPUCommandEncoder>(null);
 
 export function wLog<T extends any>(message: string, a: T): T {
   console.warn(message, a);

--- a/src/index.mts
+++ b/src/index.mts
@@ -2,7 +2,7 @@ export { group, object, u32buffer, newBufferFormatLength } from "./alias.mjs";
 
 export { createRenderer, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
 
-export { initializeContext } from "./initialize.js";
+export { initializeContext, enableBloom } from "./initialize.js";
 
 export { compButton, compDragPoint, compSlider } from "./comp/button.mjs";
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -2,7 +2,7 @@ export { group, object, u32buffer, newBufferFormatLength } from "./alias.mjs";
 
 export { createRenderer, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
 
-export { initializeContext, enableBloom } from "./initialize.js";
+export { initializeContext, enableBloom, initializeCanvasTextures } from "./initialize.js";
 
 export { compButton, compDragPoint, compSlider } from "./comp/button.mjs";
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,6 +1,6 @@
 export { group, object, u32buffer, newBufferFormatLength } from "./alias.mjs";
 
-export { createRenderer, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+export { createRenderer, paintLagopusTree, renderLagopusTree, resetCanvasSize } from "./render.mjs";
 
 export { initializeContext, enableBloom, initializeCanvasTextures } from "./initialize.js";
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,6 +1,8 @@
 export { group, object, u32buffer, newBufferFormatLength } from "./alias.mjs";
 
-export { createRenderer, initializeContext, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+export { createRenderer, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+
+export { initializeContext } from "./initialize.js";
 
 export { compButton, compDragPoint, compSlider } from "./comp/button.mjs";
 

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -64,38 +64,36 @@ export function initializeCanvasTextures() {
   let width = window.innerWidth * devicePixelRatio;
   let height = window.innerHeight * devicePixelRatio;
 
-  if (atomBloomEnabled.deref() || !atomDepthTexture.deref()) {
-    // TODO dirty fix
-    // still need to handle dynamic canvas https://webgpu.github.io/webgpu-samples/samples/resizeCanvas
+  const depthTexture = device.createTexture({
+    size: [width, height],
+    // format: "depth24plus",
+    // usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    dimension: "2d",
+    format: "depth24plus-stencil8",
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    // sampleCount: atomBloomEnabled.deref() ? undefined : 4,
+  });
 
-    const depthTexture = device.createTexture({
-      size: [width, height],
-      // format: "depth24plus",
-      // usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      dimension: "2d",
-      format: "depth24plus-stencil8",
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-    });
+  atomDepthTexture.reset(depthTexture);
 
-    atomDepthTexture.reset(depthTexture);
-  }
+  let texture = device.createTexture({
+    size: [width, height],
+    format: "bgra8unorm",
+    // sampleCount: atomBloomEnabled.deref() ? undefined : 4,
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  });
+
+  atomCanvasTexture.reset(texture);
 
   if (!atomBloomEnabled.deref()) {
     // disabled
     return;
   }
 
-  let texture = device.createTexture({
-    size: [width, height],
-    format: "bgra8unorm",
-    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
-  });
-  atomCanvasTexture.reset(texture);
-
   let filterTexture = device.createTexture({
     size: [width, height],
     format: "bgra8unorm",
+
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
   });

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -9,6 +9,7 @@ import {
   atomPongBuffer,
   atomPingTexture,
   atomPongTexture,
+  atomBloomEnabled,
 } from "./global.mjs";
 
 /** init canvas context */
@@ -63,6 +64,21 @@ export function initializeCanvasTextures() {
   let width = window.innerWidth * devicePixelRatio;
   let height = window.innerHeight * devicePixelRatio;
 
+  const depthTexture = device.createTexture({
+    size: [width, height],
+    // format: "depth24plus",
+    // usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    dimension: "2d",
+    format: "depth24plus-stencil8",
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+
+  atomDepthTexture.reset(depthTexture);
+  if (!atomBloomEnabled.deref()) {
+    // disabled
+    return;
+  }
+
   let texture = device.createTexture({
     size: [width, height],
     format: "bgra8unorm",
@@ -78,17 +94,6 @@ export function initializeCanvasTextures() {
     // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
   });
   atomFilterTexture.reset(filterTexture);
-
-  const depthTexture = device.createTexture({
-    size: [width, height],
-    // format: "depth24plus",
-    // usage: GPUTextureUsage.RENDER_ATTACHMENT,
-    dimension: "2d",
-    format: "depth24plus-stencil8",
-    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-  });
-
-  atomDepthTexture.reset(depthTexture);
 
   const buffer0 = (() => {
     const buffer = device.createBuffer({
@@ -141,4 +146,9 @@ export function initializeCanvasTextures() {
 
   atomPingTexture.reset(pingTexture);
   atomPongTexture.reset(pongTexture);
+}
+
+/** enabled bloom effect */
+export function enableBloom() {
+  atomBloomEnabled.reset(true);
 }

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -1,0 +1,144 @@
+import {
+  atomDevice,
+  atomContext,
+  atomCanvasTexture,
+  atomDepthTexture,
+  atomFilterTexture,
+  atomPingBuffer,
+  atomScreenFilterBuffer,
+  atomPongBuffer,
+  atomPingTexture,
+  atomPongTexture,
+} from "./global.mjs";
+
+/** init canvas context */
+export const initializeContext = async (): Promise<any> => {
+  // ~~ INITIALIZE ~~ Make sure we can initialize WebGPU
+  if (!navigator.gpu) {
+    console.error("WebGPU cannot be initialized - navigator.gpu not found");
+    return null;
+  }
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    console.error("WebGPU cannot be initialized - Adapter not found");
+    return null;
+  }
+  const device = await adapter.requestDevice();
+  device.lost.then(() => {
+    console.error("WebGPU cannot be initialized - Device has been lost");
+    return null;
+  });
+
+  // set as a shared device
+  atomDevice.reset(device);
+
+  const canvas = document.getElementById("canvas-container") as HTMLCanvasElement;
+  const context = canvas.getContext("webgpu");
+  if (!context) {
+    console.error("WebGPU cannot be initialized - Canvas does not support WebGPU");
+    return null;
+  }
+
+  // ~~ CONFIGURE THE SWAP CHAIN ~~
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  const presentationFormat = window.navigator.gpu.getPreferredCanvasFormat();
+
+  canvas.width = window.innerWidth * devicePixelRatio;
+  canvas.height = window.innerHeight * devicePixelRatio;
+
+  context.configure({
+    device,
+    format: presentationFormat,
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    alphaMode: "premultiplied",
+  });
+
+  // set as a shared context
+  atomContext.reset(context);
+};
+
+/** create a texture for canvas */
+export function initializeCanvasTextures() {
+  let device = atomDevice.deref();
+  let width = window.innerWidth * devicePixelRatio;
+  let height = window.innerHeight * devicePixelRatio;
+
+  let texture = device.createTexture({
+    size: [width, height],
+    format: "bgra8unorm",
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+    // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  });
+  atomCanvasTexture.reset(texture);
+
+  let filterTexture = device.createTexture({
+    size: [width, height],
+    format: "bgra8unorm",
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+    // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  });
+  atomFilterTexture.reset(filterTexture);
+
+  const depthTexture = device.createTexture({
+    size: [width, height],
+    // format: "depth24plus",
+    // usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    dimension: "2d",
+    format: "depth24plus-stencil8",
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+
+  atomDepthTexture.reset(depthTexture);
+
+  const buffer0 = (() => {
+    const buffer = device.createBuffer({
+      size: 4,
+      mappedAtCreation: true,
+      usage: GPUBufferUsage.UNIFORM,
+    });
+    new Uint32Array(buffer.getMappedRange())[0] = 0;
+    buffer.unmap();
+    return buffer;
+  })();
+
+  const buffer1 = (() => {
+    const buffer = device.createBuffer({
+      size: 4,
+      mappedAtCreation: true,
+      usage: GPUBufferUsage.UNIFORM,
+    });
+    new Uint32Array(buffer.getMappedRange())[0] = 1;
+    buffer.unmap();
+    return buffer;
+  })();
+
+  const buffer2 = (() => {
+    const buffer = device.createBuffer({
+      size: 4,
+      mappedAtCreation: true,
+      usage: GPUBufferUsage.UNIFORM,
+    });
+    new Uint32Array(buffer.getMappedRange())[0] = 1;
+    buffer.unmap();
+    return buffer;
+  })();
+
+  atomPingBuffer.reset(buffer0);
+  atomPongBuffer.reset(buffer1);
+  atomScreenFilterBuffer.reset(buffer2);
+
+  let pingTexture = device.createTexture({
+    size: [width, height],
+    format: "rgba8unorm",
+    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  });
+
+  let pongTexture = device.createTexture({
+    size: [width, height],
+    format: "rgba8unorm",
+    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  });
+
+  atomPingTexture.reset(pingTexture);
+  atomPongTexture.reset(pongTexture);
+}

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -64,16 +64,22 @@ export function initializeCanvasTextures() {
   let width = window.innerWidth * devicePixelRatio;
   let height = window.innerHeight * devicePixelRatio;
 
-  const depthTexture = device.createTexture({
-    size: [width, height],
-    // format: "depth24plus",
-    // usage: GPUTextureUsage.RENDER_ATTACHMENT,
-    dimension: "2d",
-    format: "depth24plus-stencil8",
-    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-  });
+  if (atomBloomEnabled.deref() || !atomDepthTexture.deref()) {
+    // TODO dirty fix
+    // still need to handle dynamic canvas https://webgpu.github.io/webgpu-samples/samples/resizeCanvas
 
-  atomDepthTexture.reset(depthTexture);
+    const depthTexture = device.createTexture({
+      size: [width, height],
+      // format: "depth24plus",
+      // usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      dimension: "2d",
+      format: "depth24plus-stencil8",
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+
+    atomDepthTexture.reset(depthTexture);
+  }
+
   if (!atomBloomEnabled.deref()) {
     // disabled
     return;

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,5 +1,5 @@
 import { paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
-import { initializeCanvasTextures, initializeContext } from "./initialize.js";
+import { enableBloom, initializeCanvasTextures, initializeContext } from "./initialize.js";
 
 import { compContainer } from "./app/container.mjs";
 import { renderControl, startControlLoop } from "@triadica/touch-control";
@@ -8,6 +8,7 @@ import { setupMouseEvents } from "./events.mjs";
 import { Atom } from "./atom.mjs";
 import { V3 } from "./primes.mjs";
 import { atomClearColor } from "./global.mjs";
+import { ua } from "./config.mjs";
 
 let store = new Atom({
   position: [180, 80, 80] as V3,
@@ -29,6 +30,10 @@ function renderApp() {
 }
 
 window.onload = async () => {
+  if (ua.os.name.includes("Mac OS")) {
+    enableBloom();
+  }
+
   await initializeContext();
   initializeCanvasTextures();
   atomClearColor.reset({ r: 0.4, g: 0.4, b: 0.4, a: 1.0 });

--- a/src/main.mts
+++ b/src/main.mts
@@ -8,7 +8,7 @@ import { setupMouseEvents } from "./events.mjs";
 import { Atom } from "./atom.mjs";
 import { V3 } from "./primes.mjs";
 import { atomClearColor } from "./global.mjs";
-import { ua } from "./config.mjs";
+import { isMobile } from "./config.mjs";
 
 let store = new Atom({
   position: [180, 80, 80] as V3,
@@ -30,7 +30,7 @@ function renderApp() {
 }
 
 window.onload = async () => {
-  if (ua.os.name.includes("Mac OS")) {
+  if (!isMobile) {
     enableBloom();
   }
 

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,4 +1,5 @@
-import { initializeCanvasTextures, initializeContext, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+import { paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+import { initializeCanvasTextures, initializeContext } from "./initialize.js";
 
 import { compContainer } from "./app/container.mjs";
 import { renderControl, startControlLoop } from "@triadica/touch-control";

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,4 +1,4 @@
-import { initializeContext, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+import { initializeCanvasTextures, initializeContext, paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
 
 import { compContainer } from "./app/container.mjs";
 import { renderControl, startControlLoop } from "@triadica/touch-control";
@@ -29,6 +29,7 @@ function renderApp() {
 
 window.onload = async () => {
   await initializeContext();
+  initializeCanvasTextures();
   atomClearColor.reset({ r: 0.92, g: 0.92, b: 0.92, a: 1.0 });
   let canvas = document.querySelector("canvas");
   renderApp();
@@ -39,6 +40,7 @@ window.onload = async () => {
 
   window.onresize = () => {
     resetCanvasHeight(canvas);
+    initializeCanvasTextures();
     paintLagopusTree();
   };
   resetCanvasHeight(canvas);

--- a/src/main.mts
+++ b/src/main.mts
@@ -30,7 +30,7 @@ function renderApp() {
 window.onload = async () => {
   await initializeContext();
   initializeCanvasTextures();
-  atomClearColor.reset({ r: 0.92, g: 0.92, b: 0.92, a: 1.0 });
+  atomClearColor.reset({ r: 0.4, g: 0.4, b: 0.4, a: 1.0 });
   let canvas = document.querySelector("canvas");
   renderApp();
   console.log("loaded");

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,4 +1,4 @@
-import { paintLagopusTree, renderLagopusTree, resetCanvasHeight } from "./render.mjs";
+import { paintLagopusTree, renderLagopusTree, resetCanvasSize } from "./render.mjs";
 import { enableBloom, initializeCanvasTextures, initializeContext } from "./initialize.js";
 
 import { compContainer } from "./app/container.mjs";
@@ -45,11 +45,11 @@ window.onload = async () => {
   startControlLoop(10, onControlEvent);
 
   window.onresize = () => {
-    resetCanvasHeight(canvas);
+    resetCanvasSize(canvas);
     initializeCanvasTextures();
     paintLagopusTree();
   };
-  resetCanvasHeight(canvas);
+  resetCanvasSize(canvas);
 
   window.__lagopusHandleCompilationInfo = (e, code) => {
     if (e.messages.length) {

--- a/src/render.mts
+++ b/src/render.mts
@@ -16,6 +16,7 @@ import {
   atomFilterTexture,
   atomPingTexture,
   atomPongTexture,
+  atomBloomEnabled,
 } from "./global.mjs";
 import { coneBackScale } from "./config.mjs";
 import { atomViewerPosition, atomViewerUpward, newLookatPoint } from "./perspective.mjs";
@@ -202,8 +203,15 @@ let buildCommandBuffer = (info: LagopusObjectData): void => {
 
   atomBufferNeedClear.reset(false);
 
+  let renderTarget: GPUTexture;
+  if (atomBloomEnabled.deref()) {
+    renderTarget = atomCanvasTexture.deref();
+  } else {
+    renderTarget = context.getCurrentTexture();
+  }
+
   // renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture().createView();
-  renderPassDescriptor.colorAttachments[0].view = atomCanvasTexture.deref().createView();
+  renderPassDescriptor.colorAttachments[0].view = renderTarget.createView();
   renderPassDescriptor.depthStencilAttachment.view = depthTexture.createView();
   const commandEncoder = atomCommandEncoder.deref();
   const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
@@ -264,7 +272,9 @@ export function paintLagopusTree() {
   let tree = atomLagopusTree.deref();
   collectBuffers(tree);
 
-  postRendering();
+  if (atomBloomEnabled.deref()) {
+    postRendering();
+  }
 
   // load shared device
   let commandEncoder = atomCommandEncoder.deref();

--- a/src/render.mts
+++ b/src/render.mts
@@ -161,9 +161,7 @@ let buildCommandBuffer = (info: LagopusObjectData): void => {
     ...(info.addUniform?.() || []),
   ]);
 
-  let uniformBuffer: GPUBuffer = null;
-
-  uniformBuffer = createBuffer(uniformData, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
+  let uniformBuffer = createBuffer(uniformData, GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
   // console.log(info.addUniform?.(), uniformData.length, uniformBuffer);
 
   let uniformBindGroupLayout = device.createBindGroupLayout({
@@ -502,6 +500,10 @@ export function postRendering() {
         binding: 1,
         resource: textures[0].createView(),
       },
+      {
+        binding: 2,
+        resource: canvasTexture.createView(),
+      },
     ],
   });
 
@@ -539,10 +541,7 @@ export function resetCanvasHeight(canvas: HTMLCanvasElement) {
 export function initializeCanvasTextures() {
   let device = atomDevice.deref();
   let texture = device.createTexture({
-    size: {
-      width: window.innerWidth * devicePixelRatio,
-      height: window.innerHeight * devicePixelRatio,
-    },
+    size: [window.innerWidth * devicePixelRatio, window.innerHeight * devicePixelRatio],
     format: "bgra8unorm",
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     // usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
   integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
 
+"@types/ua-parser-js@^0.7.36":
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
+  integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
+
 "@webgpu/types@^0.1.30":
   version "0.1.30"
   resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.30.tgz#b6406dc4a1c1e0d469028ceb30ddffbbd2fa706c"
@@ -262,6 +267,11 @@ typescript@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
   integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
+
+ua-parser-js@^1.0.35:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
+  integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
 
 vite-plugin-glsl@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
based on work of https://webgpu.github.io/webgpu-samples/samples/imageBlur .

this attempt is really slow. if someone find this from Google, here some brief of this PR:

- I reused some code from image blur to create bloom effect, not very good,
- I used multiple passes, 1. render to a texture, 2. filter bright color to new texture, 3. move data to pingpong texture, 4. pingpong rendering maybe, 5. mix data into a real canvas.
- the result is really slow, and it only worked for macOS Chrome Canary, at least for now. so I disabled effect for Android.
- blur is not good implementation for bloom, read more at https://www.youtube.com/watch?v=ml-5OGZC7vE